### PR TITLE
Fix template path and README run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It uses Flask for a minimal dashboard and OpenAI LLMs for text generation.
    ```
 4. Run the application:
    ```bash
-   poetry run flask --app src.app run
+   PYTHONPATH=src poetry run flask --app app run
    ```
 
 ## Docker

--- a/src/app.py
+++ b/src/app.py
@@ -12,7 +12,7 @@ from agents.approval_agent import approve, load_guardrails
 
 load_dotenv()
 
-app = Flask(__name__)
+app = Flask(__name__, template_folder=os.path.join(os.path.dirname(__file__), "../templates"))
 GUARDRAILS_PATH = Path("data/guardrails.txt")
 
 


### PR DESCRIPTION
## Summary
- point Flask to templates directory in project root
- correct README instructions for running the app

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68401e4b0d74832ebf5050d126f9ae00