### PR TITLE
Add brief validation and UI loop

### DIFF
--- a/src/agents/brief_agent.py
+++ b/src/agents/brief_agent.py
@@ -5,3 +5,32 @@ def collect_brief(form_data: dict) -> dict:
         "keywords": form_data.get("keywords", ""),
         "description": form_data.get("description", ""),
     }
+
+
+def validate_brief(brief: dict) -> tuple[bool, list[str]]:
+    """Check that all required fields are present.
+
+    Parameters
+    ----------
+    brief:
+        Dictionary containing the collected brief data.
+
+    Returns
+    -------
+    tuple[bool, list[str]]
+        A tuple where the first element indicates if the brief is valid and the
+        second element is a list of prompts for any missing fields.
+    """
+
+    required_prompts = {
+        "title": "Please provide an article title.",
+        "description": "Please add a short description of the article.",
+        "keywords": "Please specify keywords for the article.",
+    }
+
+    prompts = [
+        message
+        for field, message in required_prompts.items()
+        if not brief.get(field, "").strip()
+    ]
+    return len(prompts) == 0, prompts


### PR DESCRIPTION
## Summary
- require the brief to include title, description and keywords
- warn users about missing fields in the Streamlit UI before generating content

## Testing
- `pre-commit run --files src/agents/brief_agent.py src/streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684029c3add0832e9a7017c053bc5dfc