### PR TITLE
Improve agent interactivity and logging

### DIFF
--- a/src/agents/brief_agent.py
+++ b/src/agents/brief_agent.py
@@ -1,7 +1,16 @@
-def collect_brief(form_data: dict) -> dict:
-    """Return collected brief data."""
+from __future__ import annotations
+
+def collect_brief(form_data: dict) -> tuple[dict | None, str | None]:
+    """Validate form input and return brief data or a follow-up question."""
+    title = form_data.get("title", "").strip()
+    keywords = form_data.get("keywords", "").strip()
+    description = form_data.get("description", "").strip()
+
+    if len(description) < 30:
+        return None, "Could you provide more detail in the description?"
+
     return {
-        "title": form_data.get("title", ""),
-        "keywords": form_data.get("keywords", ""),
-        "description": form_data.get("description", ""),
-    }
+        "title": title,
+        "keywords": keywords,
+        "description": description,
+    }, None

--- a/src/agents/content_agent.py
+++ b/src/agents/content_agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import openai
+import requests
 
 
 class ContentAgent:
@@ -8,10 +9,28 @@ class ContentAgent:
         openai.api_key = api_key
         self.model = model
 
-    def generate_draft(self, brief: dict) -> str:
+    def _fetch_trending_keywords(self, topic: str) -> list[str]:
+        """Return a list of trending keywords for the given topic."""
+        try:
+            resp = requests.get(
+                "https://api.datamuse.com/words",
+                params={"ml": topic, "max": 5},
+                timeout=5,
+            )
+            resp.raise_for_status()
+            return [w.get("word", "") for w in resp.json()]
+        except Exception:
+            return []
+
+    def fetch_trending_keywords(self, topic: str) -> list[str]:
+        return self._fetch_trending_keywords(topic)
+
+    def generate_draft(self, brief: dict, trending: list[str] | None = None) -> str:
+        trending = trending or []
+        all_keywords = ", ".join([kw for kw in [brief.get("keywords", "")] + trending if kw])
         prompt = (
             f"Write a blog post titled '{brief['title']}' about {brief['description']}.\n"
-            f"Include the keywords: {brief['keywords']}."
+            f"Include the keywords: {all_keywords}."
         )
         response = openai.chat.completions.create(
             model=self.model,

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import streamlit as st
 from dotenv import load_dotenv
+import pandas as pd
 
 from agents.brief_agent import collect_brief
 from agents.content_agent import ContentAgent
@@ -121,9 +122,11 @@ def result_page() -> None:
             st.error(f"Status: Rejected - {st.session_state.get('feedback', '')}")
 
     with tabs[1]:
-        st.write("Job | Agent | Time taken | Status")
-        for log in st.session_state.logs:
-            st.write(f"{log['job']} | {log['agent']} | {log['time']}s | {log['status']}")
+        if st.session_state.logs:
+            df = pd.DataFrame(st.session_state.logs)
+            st.table(df)
+        else:
+            st.info("No logs yet.")
 
     if st.button("Back"):
         st.session_state.page = "home"

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -88,6 +88,14 @@ def home_page() -> None:
                 guardrails = load_guardrails(GUARDRAILS_PATH)
                 ok, feedback = approve(draft, guardrails)
                 _log("Review draft", "approval agent", start)
+                if ok:
+                    _log("Approved draft", "approval agent", time.perf_counter())
+                else:
+                    _log(
+                        "Raise revision request",
+                        "approval agent",
+                        time.perf_counter(),
+                    )
 
             st.session_state.draft = draft
             st.session_state.approved = ok


### PR DESCRIPTION
## Summary
- collect detailed briefs interactively
- pull trending keywords from datamuse API
- log agent actions and display them in Streamlit
- update Streamlit workflow with an interactive brief form and logs tab

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684037ff0c40832e9bca5736d4f01619